### PR TITLE
Vercel endpoints

### DIFF
--- a/lib/turbo_web.ex
+++ b/lib/turbo_web.ex
@@ -28,15 +28,17 @@ defmodule TurboWeb do
       @doc """
       Render response in JSON format with the appropriate headers
       """
-      def send_json_resp(conn, http_status, map) do
+      @spec send_json_resp(Plug.Conn.t(), integer(), map()) :: Plug.Conn.t() | none()
+      def send_json_resp(conn, http_status, params) do
         conn
         |> put_resp_header("content-type", "application/json")
-        |> send_resp(http_status, Jason.encode!(map))
+        |> send_resp(http_status, Jason.encode!(params))
       end
 
       @doc """
       Send stream to the client by reducing over the stream
       """
+      @spec send_chunked_stream(Plug.Conn.t(), Enumerable.t()) :: Plug.Conn.t() | none()
       def send_chunked_stream(conn, stream) do
         Enum.reduce_while(stream, conn, fn file_chunk, conn ->
           case chunk(conn, file_chunk) do

--- a/lib/turbo_web.ex
+++ b/lib/turbo_web.ex
@@ -25,7 +25,18 @@ defmodule TurboWeb do
       import TurboWeb.Gettext
       alias TurboWeb.Router.Helpers, as: Routes
 
-      # Send stream to the client by reducing over the stream
+      @doc """
+      Render response in JSON format with the appropriate headers
+      """
+      def send_json_resp(conn, http_status, map) do
+        conn
+        |> put_resp_header("content-type", "application/json")
+        |> send_resp(http_status, Jason.encode!(map))
+      end
+
+      @doc """
+      Send stream to the client by reducing over the stream
+      """
       def send_chunked_stream(conn, stream) do
         Enum.reduce_while(stream, conn, fn file_chunk, conn ->
           case chunk(conn, file_chunk) do

--- a/lib/turbo_web/controllers/artifact_controller.ex
+++ b/lib/turbo_web/controllers/artifact_controller.ex
@@ -27,6 +27,12 @@ defmodule TurboWeb.ArtifactController do
     |> send_resp(201, Jason.encode!(%{filename: filename}))
   end
 
+  # TODO: Looks like this is an analytics endpoint used by Vercel
+  # to collect metrics. We could probably aggregate on it later on
+  def events(conn, _params) do
+    send_resp(conn, 201, Jason.encode!(%{}))
+  end
+
   def show(conn, %{"hash" => hash} = _params) do
     FileStore.get_file(hash)
     |> stream_resp(conn)

--- a/lib/turbo_web/controllers/artifact_controller.ex
+++ b/lib/turbo_web/controllers/artifact_controller.ex
@@ -30,7 +30,7 @@ defmodule TurboWeb.ArtifactController do
   # TODO: Looks like this is an analytics endpoint used by Vercel
   # to collect metrics. We could probably aggregate on it later on
   def events(conn, _params) do
-    send_resp(conn, 201, Jason.encode!(%{}))
+    send_json_resp(conn, 201, %{})
   end
 
   def show(conn, %{"hash" => hash} = _params) do

--- a/lib/turbo_web/controllers/team_controller.ex
+++ b/lib/turbo_web/controllers/team_controller.ex
@@ -4,10 +4,10 @@ defmodule TurboWeb.TeamController do
   # TODO: These endpoints seem to be used by Vercel only
   # But we can probably hook up an UI here later on.
   def user(conn, _params) do
-    send_resp(conn, 200, Jason.encode!(%{}))
+    send_json_resp(conn, 200, %{})
   end
 
   def teams(conn, _params) do
-    send_resp(conn, 200, Jason.encode!(%{}))
+    send_json_resp(conn, 200, %{})
   end
 end

--- a/lib/turbo_web/controllers/team_controller.ex
+++ b/lib/turbo_web/controllers/team_controller.ex
@@ -1,0 +1,13 @@
+defmodule TurboWeb.TeamController do
+  use TurboWeb, :controller
+
+  # TODO: These endpoints seem to be used by Vercel only
+  # But we can probably hook up an UI here later on.
+  def user(conn, _params) do
+    send_resp(conn, 200, Jason.encode!(%{}))
+  end
+
+  def teams(conn, _params) do
+    send_resp(conn, 200, Jason.encode!(%{}))
+  end
+end

--- a/lib/turbo_web/router.ex
+++ b/lib/turbo_web/router.ex
@@ -24,6 +24,12 @@ defmodule TurboWeb.Router do
   scope "/v8", TurboWeb do
     get "/artifacts/:hash", ArtifactController, :show
     put "/artifacts/:hash", ArtifactController, :create
+    post "/artifacts/events", ArtifactController, :events
+  end
+
+  scope "/v2", TurboWeb do
+    get "/teams", TeamController, :teams
+    get "/user", TeamController, :user
   end
 
   # Other scopes may use custom stacks.

--- a/test/turbo_web/controllers/artifact_controller_test.exs
+++ b/test/turbo_web/controllers/artifact_controller_test.exs
@@ -23,4 +23,9 @@ defmodule TurboWeb.ArtifactControllerTest do
     assert response(conn, 200) =~ "i_am_some_binary"
     {:ok, _} = FileStore.delete_file(hash)
   end
+
+  test "POST /v8/artifacts/events should respond with an empty JSON", %{conn: conn} do
+    conn = post(conn, "/v8/artifacts/events")
+    assert json_response(conn, 201) == %{}
+  end
 end

--- a/test/turbo_web/controllers/team_controller_test.exs
+++ b/test/turbo_web/controllers/team_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule TurboWeb.TeamControllerTest do
+  use TurboWeb.ConnCase
+
+  test "GET /v2/teams should respond with an empty JSON", %{conn: conn} do
+    conn = get(conn, "/v2/teams")
+    assert json_response(conn, 200) == %{}
+  end
+
+  test "GET /v2/user should respond with an empty JSON", %{conn: conn} do
+    conn = get(conn, "/v2/user")
+    assert json_response(conn, 200) == %{}
+  end
+end


### PR DESCRIPTION
These endpoints seem to be Vercel-specific. Implementing them here with dummy responses for now, but I can probably add an UI around them later on. Turborepo seems to work 100% fine, even with the dummy responses.

Here is the output of `turbo build` in a local monorepo running against the this backend running in localhost:

```log
pnpm build                

> @ultimate-monorepo@1.0.0 build /Users/bruno/code/ultimate-monorepo
> turbo run build --api="http://localhost:4000" --token="secret-token" --team="bruno-team"

• Packages in scope: , @ultimate-monorepo/core, @ultimate-monorepo/docs, @ultimate-monorepo/web
• Running build in 4 packages
• Remote computation caching enabled
@ultimate-monorepo/core:build: cache hit, replaying output a7644fbc81f0095d
@ultimate-monorepo/core:build: 
@ultimate-monorepo/core:build: > @ultimate-monorepo/core@1.0.0 build /Users/bruno/code/ultimate-monorepo/packages/core
@ultimate-monorepo/core:build: > tsc && vite build
@ultimate-monorepo/core:build: 
@ultimate-monorepo/core:build: vite v2.9.9 building for production...
@ultimate-monorepo/core:build: transforming...
@ultimate-monorepo/core:build: ✓ 12 modules transformed.
@ultimate-monorepo/core:build: rendering chunks...
@ultimate-monorepo/core:build: dist/ultimate-components.es.js   1.80 KiB / gzip: 0.81 KiB
@ultimate-monorepo/core:build: dist/ultimate-components.umd.js   1.67 KiB / gzip: 0.90 KiB
@ultimate-monorepo/core:build: 
@ultimate-monorepo/core:build: [vite:dts] Start generate declaration files...
@ultimate-monorepo/core:build: [vite:dts] Declaration files built in 715ms.
@ultimate-monorepo/core:build: 
@ultimate-monorepo/web:build: cache hit, replaying output 9663fa01b291c6d0
@ultimate-monorepo/web:build: 
@ultimate-monorepo/web:build: > @ultimate-monorepo/web@0.2.1 build /Users/bruno/code/ultimate-monorepo/apps/web
@ultimate-monorepo/web:build: > next build
@ultimate-monorepo/web:build: 
@ultimate-monorepo/web:build: info  - Checking validity of types...
@ultimate-monorepo/web:build: info  - Creating an optimized production build...
@ultimate-monorepo/web:build: info  - Compiled successfully
@ultimate-monorepo/web:build: info  - Collecting page data...
@ultimate-monorepo/web:build: info  - Generating static pages (0/3)
@ultimate-monorepo/web:build: info  - Generating static pages (3/3)
@ultimate-monorepo/web:build: info  - Finalizing page optimization...
@ultimate-monorepo/web:build: 
@ultimate-monorepo/web:build: Page                                       Size     First Load JS
@ultimate-monorepo/web:build: ┌ ○ /                                      6.73 kB        81.7 kB
@ultimate-monorepo/web:build: ├   └ css/149b18973e5508c7.css             655 B
@ultimate-monorepo/web:build: ├   /_app                                  0 B            74.9 kB
@ultimate-monorepo/web:build: ├ ○ /404                                   195 B          75.1 kB
@ultimate-monorepo/web:build: └ λ /api/hello                             0 B            74.9 kB
@ultimate-monorepo/web:build: + First Load JS shared by all              74.9 kB
@ultimate-monorepo/web:build:   ├ chunks/framework-1d9b4f8c693ff0b7.js   45 kB
@ultimate-monorepo/web:build:   ├ chunks/main-d0e756fdb319e528.js        28.7 kB
@ultimate-monorepo/web:build:   ├ chunks/pages/_app-23c6af3a6c4c100a.js  496 B
@ultimate-monorepo/web:build:   ├ chunks/webpack-69bfa6990bb9e155.js     769 B
@ultimate-monorepo/web:build:   └ css/27d177a30947857b.css               194 B
@ultimate-monorepo/web:build: 
@ultimate-monorepo/web:build: λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
@ultimate-monorepo/web:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
@ultimate-monorepo/web:build: 
@ultimate-monorepo/docs:build: cache hit, replaying output 7a2f51302c06fb57
@ultimate-monorepo/docs:build: 
@ultimate-monorepo/docs:build: > @ultimate-monorepo/docs@0.1.5 build /Users/bruno/code/ultimate-monorepo/apps/docs
@ultimate-monorepo/docs:build: > next build
@ultimate-monorepo/docs:build: 
@ultimate-monorepo/docs:build: info  - Checking validity of types...
@ultimate-monorepo/docs:build: info  - Creating an optimized production build...
@ultimate-monorepo/docs:build: info  - Compiled successfully
@ultimate-monorepo/docs:build: info  - Collecting page data...
@ultimate-monorepo/docs:build: info  - Generating static pages (0/4)
@ultimate-monorepo/docs:build: info  - Generating static pages (1/4)
@ultimate-monorepo/docs:build: info  - Generating static pages (2/4)
@ultimate-monorepo/docs:build: info  - Generating static pages (3/4)
@ultimate-monorepo/docs:build: info  - Generating static pages (4/4)
@ultimate-monorepo/docs:build: info  - Finalizing page optimization...
@ultimate-monorepo/docs:build: 
@ultimate-monorepo/docs:build: Page                                       Size     First Load JS
@ultimate-monorepo/docs:build: ┌ ○ /                                      973 B           138 kB
@ultimate-monorepo/docs:build: ├   /_app                                  0 B            74.9 kB
@ultimate-monorepo/docs:build: ├ ○ /404                                   195 B          75.1 kB
@ultimate-monorepo/docs:build: └ ○ /how-to/instructions                   918 B           138 kB
@ultimate-monorepo/docs:build: + First Load JS shared by all              74.9 kB
@ultimate-monorepo/docs:build:   ├ chunks/framework-58732a32099dd011.js   45 kB
@ultimate-monorepo/docs:build:   ├ chunks/main-fdddd7732bc773e3.js        28.6 kB
@ultimate-monorepo/docs:build:   ├ chunks/pages/_app-aa9afc42b682662b.js  509 B
@ultimate-monorepo/docs:build:   ├ chunks/webpack-d7b038a63b619762.js     771 B
@ultimate-monorepo/docs:build:   └ css/f6eab16f921f349f.css               5.26 kB
@ultimate-monorepo/docs:build: 
@ultimate-monorepo/docs:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
@ultimate-monorepo/docs:build: 

 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    385ms >>> FULL TURBO
```