### PR TITLE
Using Ubuntu to build arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,10 @@
 name: Docker Build
-on: push
+on:
+  workflow_dispatch:
+    inputs: {}
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: false
-# on:
-#   workflow_dispatch:
-#     inputs: {}
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,11 @@
 name: Docker Build
-on:
-  workflow_dispatch:
-    inputs: {}
+on: push
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: false
+# on:
+#   workflow_dispatch:
+#     inputs: {}
 
 jobs:
   build:
@@ -28,9 +32,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: 'linux/amd64'
-          # If we need to support arm64 eventually, use the following config.
-          # But it's currently raising a segfault during build.
-          # platforms: 'linux/amd64,linux/arm64'
+          platforms: 'linux/amd64,linux/arm64'
           push: '${{ github.event_name != ''pull_request'' }}'
           tags: 'brunojppb/turbo-racer:1.0.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian instead of
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Ubuntu instead of
 # Alpine to avoid DNS resolution issues in production.
 #
 # https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=ubuntu
@@ -8,16 +8,16 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20210902-slim - for the release image
+#   - https://hub.docker.com/_/ubuntu?tab=tags&page=1&name=xenial-20210804 - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.13.4-erlang-24.2.1-debian-bullseye-20210902-slim
+#   - Ex: hexpm/elixir:1.13.4-erlang-25.0.4-ubuntu-xenial-20210804
 #
 ARG ELIXIR_VERSION=1.13.4
 ARG OTP_VERSION=25.0.4
-ARG DEBIAN_VERSION=bullseye-20220801-slim
+ARG UBUNTU_VERSION=xenial-20210804
 
-ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
-ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-ubuntu-${UBUNTU_VERSION}"
+ARG RUNNER_IMAGE="ubuntu:${UBUNTU_VERSION}"
 
 FROM ${BUILDER_IMAGE} as builder
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,12 +4,13 @@ volumes:
 services:
 
   turbo_racer_app:
+    image: brunojppb/turbo-racer:1.0.0
     container_name: turbo_racer_app
-    build:
-      context: .
     environment:
       # Postgres database URL pattern expected by Ecto: ecto://USER:PASS@HOST/DATABASE
       - DATABASE_URL=ecto://turbo_racer:please_replace_me@turbo_racer_db/turbo_racer
+      # DB variables used by the entrypoint script
+      #  for checking if the DB is available before starting the app
       - DATABASE_HOST=turbo_racer_db
       - DATABASE_USER=turbo_racer
       - SECRET_KEY_BASE=please_replace_me_with_something_random_and_strong_at_least_64_characters_long


### PR DESCRIPTION
I've found out that the Debian image version was raising some segmentation fault errors, but it seems due to the new JIT in OTP 24 and above. ([Elixir Forum link here](https://elixirforum.com/t/building-elixir-erlang-linux-amd64-application-image-on-apple-silicon/43913))

Using Ubuntu Xenial seems to work fine and the final image size seems to be small.

Turbo Racer docker images here:
https://hub.docker.com/repository/docker/brunojppb/turbo-racer